### PR TITLE
Add detailed docstring to play_vs_model

### DIFF
--- a/play_vs_model.py
+++ b/play_vs_model.py
@@ -6,25 +6,48 @@ from gomoku_env import GomokuEnv
 from agents import PolicyAgent, RandomAgent
 
 def play_game_with_trained_model(policy_path="policy_agent_trained.pth"):
+    """
+    学習済みモデルを用いて1ゲームだけ対戦を行う関数。
+
+    Parameters
+    ----------
+    policy_path : str
+        黒番の ``PolicyAgent`` が読み込むモデルファイルのパス。
+
+    Returns
+    -------
+    None
+        対局結果を標準出力に表示するのみで、値は返さない。
+
+    Notes
+    -----
+    黒番は ``PolicyAgent``、白番は ``RandomAgent`` が担当する。
+    """
     # 学習済みモデルを読み込んだPolicyAgent(黒番)とRandomAgent(白番)で対戦
     env = GomokuEnv(board_size=9)
+    # 黒番となる学習済みエージェントを初期化
     black_agent = PolicyAgent(board_size=9)
     black_agent.load_model(policy_path)
-    
+
+    # 白番は単純なランダムエージェント
     white_agent = RandomAgent()
-    
+
+    # ゲーム環境の初期化
     obs = env.reset()
     done = False
     
     while not done:
+        # どちらの手番かで使用するエージェントを切り替える
         if env.current_player == 1:  # 黒
             action = black_agent.get_action(obs, env)
         else:  # 白
             action = white_agent.get_action(obs, env)
-        
+
+        # 行動を環境へ適用し盤面を更新
         obs, reward, done, info = env.step(action)
-        env.render()
+        env.render()  # 盤面を表示
     
+    # ゲーム終了後に勝者を判定
     winner = info["winner"]
     if winner == 1:
         print("黒番(PolicyAgent)の勝ち！")


### PR DESCRIPTION
## Summary
- document play_game_with_trained_model with a Japanese docstring
- clarify black/white agent roles and model path parameter
- add Japanese comments for readability

## Testing
- `python -m py_compile play_vs_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68778ed337d4832c818998bca78105cd