### PR TITLE
Add docstring for RandomAgent

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -145,6 +145,11 @@ def mask_q_values(q_values: np.ndarray, valid_actions: list[int], invalid_value:
 # ランダムエージェント (学習しない)
 # ----------------------------------------------------
 class RandomAgent:
+    """
+    ランダムに着手するだけの単純なエージェント。
+
+    学習は一切行わず、合法手の中からランダムに行動を選択する。
+    """
     def __init__(self):
         pass
 


### PR DESCRIPTION
## Summary
- add a Japanese docstring to RandomAgent clarifying that it only selects moves randomly and does not learn

## Testing
- `python -m py_compile agents.py`

------
https://chatgpt.com/codex/tasks/task_e_68778ed3dc88832c85cc4780993469fe