### PR TITLE
Add Japanese module docstrings

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,5 +1,12 @@
 # agents.py
 
+"""各種エージェントクラスを定義するモジュール。
+
+ランダム戦略から強化学習ベースのエージェントまでを実装し、
+他のスクリプトからインポートして ``get_action`` を呼び出すことで
+対戦や学習に利用できる。
+"""
+
 import random
 import numpy as np
 import torch

--- a/evaluate_models.py
+++ b/evaluate_models.py
@@ -1,3 +1,11 @@
+"""学習済みモデルの性能を評価するスクリプト。
+
+指定した ``PolicyAgent`` を他のエージェントと複数回対戦させ、
+黒番の勝率を計算する。
+例:
+    $ python evaluate_models.py
+"""
+
 import numpy as np
 import torch
 from pathlib import Path

--- a/learn_model.py
+++ b/learn_model.py
@@ -1,5 +1,11 @@
 # learn_model.py
 
+"""強化学習エージェントを自己対戦させて学習させるためのスクリプト。
+
+PolicyAgent や QAgent の学習例が含まれており、
+関数呼び出しを通して各種パラメータを調整できる。
+"""
+
 import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path

--- a/learning_all_in_one.py
+++ b/learning_all_in_one.py
@@ -1,3 +1,9 @@
+"""ゲーム環境から学習ループまでを一つにまとめた実験用スクリプト。
+
+五目並べ環境の実装と強化学習によるエージェント学習を
+このファイルだけで確認できる。
+"""
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/parallel_train.py
+++ b/parallel_train.py
@@ -1,4 +1,10 @@
 # parallel_train.py
+
+"""複数プロセスによる自己対戦でモデルを学習するサンプルスクリプト。
+
+REINFORCE 法を用いてワーカーごとにエピソードを収集し、
+メインプロセスでまとめてパラメータ更新を行う。
+"""
 import numpy as np
 import multiprocessing
 from tqdm import tqdm

--- a/play_vs_model.py
+++ b/play_vs_model.py
@@ -1,4 +1,11 @@
 # play_vs_model.py
+
+"""端末上で学習済みモデルと対戦するための簡易インタフェース。
+
+黒番に ``PolicyAgent`` を読み込み、白番は ``RandomAgent`` との対戦を
+1 ゲームだけ実行する。コマンドラインから次のように利用する。
+    $ python play_vs_model.py
+"""
 import torch
 import numpy as np
 from pathlib import Path

--- a/play_with_pygame.py
+++ b/play_with_pygame.py
@@ -1,5 +1,11 @@
 # play_with_pygame.py
 
+"""Pygame を用いて GUI 上で対戦を可視化するスクリプト。
+
+学習済みモデルやヒューリスティックエージェントを組み合わせ、
+1 ゲームのみ盤面を表示しながらプレイする際に使用する。
+"""
+
 import pygame
 import sys
 import time

--- a/round_robin.py
+++ b/round_robin.py
@@ -1,5 +1,11 @@
 # round_robin.py
 
+"""複数のエージェントを総当たり戦させて勝率表を作成するスクリプト。
+
+`round_robin_tournament` 関数を利用して全ての組み合わせを評価し、
+成績やランキングを算出する。
+"""
+
 import numpy as np
 from tqdm import tqdm
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary
- describe purpose of gomoku scripts in Japanese module docstrings

## Testing
- `python -m py_compile agents.py evaluate_models.py play_with_pygame.py play_vs_model.py parallel_train.py learn_model.py round_robin.py learning_all_in_one.py`

------
https://chatgpt.com/codex/tasks/task_e_687797becc00832cb9961ea6e3fa4684