### PR TITLE
Fix comments to Japanese

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -381,7 +381,8 @@ class PolicyAgent:
 
         # 2) ネットワーク推論
         with torch.no_grad():
-            logits = self.model(state_t)  # shape: (1, board_size*board_size)
+            # logits のテンソル形状は (1, board_size*board_size)
+            logits = self.model(state_t)
             # ここでソフトマックス温度を適用
             scaled_logits = logits / self.temp
             probs = F.softmax(scaled_logits, dim=1).cpu().numpy().flatten()

--- a/learning_all_in_one.py
+++ b/learning_all_in_one.py
@@ -697,7 +697,8 @@ class PolicyNet(nn.Module):
         self.fc2 = nn.Linear(hidden_size, output_dim)
 
     def forward(self, x):
-        # x shape: (batch_size, board_size*board_size)
+        # x のテンソル形状は (batch_size, board_size*board_size)
+        # バッチごとに盤面をフラットにした入力が渡される
         h = F.relu(self.fc1(x))
         logits = self.fc2(h)
         return logits
@@ -748,7 +749,8 @@ class PolicyAgent:
         state_t = torch.tensor(obs.flatten(), dtype=torch.float32).unsqueeze(0)
 
         # 2) ネットワーク推論 (logits)  ← 勾配を追跡したいので no_grad() は付けない
-        logits = self.model(state_t)  # shape: (1, board_size*board_size)
+        # 出力 logits のテンソル形状は (1, board_size*board_size)
+        logits = self.model(state_t)
 
         # ソフトマックス温度を適用
         scaled_logits = logits / self.temp
@@ -811,7 +813,8 @@ class PolicyAgent:
         actions = [x[1] for x in self.episode_log]
         returns_t = torch.tensor(returns, dtype=torch.float32)
         logits_list = [x[3] for x in self.episode_log]
-        logits_cat = torch.cat(logits_list, dim=0)  # shape: (T, board_size^2)
+        # T はエピソード長を表し、結合後のテンソル形状は (T, board_size^2)
+        logits_cat = torch.cat(logits_list, dim=0)
 
         # 4) 順伝播して log_prob, entropy を計算 (エピソード分まとめて一気に)
         log_probs = F.log_softmax(logits_cat, dim=1)  # (T, board_size^2)
@@ -865,7 +868,8 @@ class QNet(nn.Module):
         self.fc2 = nn.Linear(hidden_size, output_dim)
 
     def forward(self, x):
-        # x shape: (batch_size, board_size^2)
+        # x のテンソル形状は (batch_size, board_size^2)
+        # DQN への入力も盤面をフラット化したベクトル
         h = F.relu(self.fc1(x))
         q = self.fc2(h)
         return q


### PR DESCRIPTION
## Summary
- update English comments mentioning tensor shape into Japanese in `agents.py`
- reword `learning_all_in_one.py` comments about tensor shapes

## Testing
- `python -m py_compile agents.py learning_all_in_one.py`

------
https://chatgpt.com/codex/tasks/task_e_687797c35a9c832c8e0cb3d137e99522