### PR TITLE
Add docstrings for unused agent methods

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -168,15 +168,19 @@ class RandomAgent:
         return random.choice(valid_actions)
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "random_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "random_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -214,15 +218,19 @@ class ImmediateWinBlockAgent:
 
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "immediate_win_block_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "immediate_win_block_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -267,15 +275,19 @@ class FourThreePriorityAgent:
 
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "four_three_priority_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "four_three_priority_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -322,15 +334,19 @@ class LongestChainAgent:
         return score
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "longest_chain_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "longest_chain_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -607,6 +623,7 @@ class QAgent:
         self.optimizer.step()
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "q_agent.pth"):

--- a/learning_all_in_one.py
+++ b/learning_all_in_one.py
@@ -429,18 +429,23 @@ class RandomAgent:
         return random.choice(valid_actions)
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def record_reward(self, r):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "random_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "random_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -513,18 +518,23 @@ class ImmediateWinBlockAgent:
         return False
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def record_reward(self, r):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "immediate_win_block_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "immediate_win_block_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -602,18 +612,23 @@ class FourThreePriorityAgent:
         return False
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def record_reward(self, r):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "four_three_priority_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "four_three_priority_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -670,18 +685,23 @@ class LongestChainAgent:
         return max_len
 
     def record_transition(self, s, a, r, s_next, done):
+        """このエージェントでは未使用"""
         pass
 
     def record_reward(self, r):
+        """このエージェントでは未使用"""
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "longest_chain_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
     def load_model(self, path=MODEL_DIR / "longest_chain_agent.pth"):
+        """このエージェントでは未使用"""
         pass
 
 
@@ -1003,6 +1023,7 @@ class QAgent:
         pass
 
     def finish_episode(self):
+        """このエージェントでは未使用"""
         pass
 
     def save_model(self, path=MODEL_DIR / "q_agent.pth"):


### PR DESCRIPTION
## Summary
- add Japanese notes explaining unused agent methods in `agents.py`
- do the same in `learning_all_in_one.py`

## Testing
- `python -m py_compile agents.py learning_all_in_one.py`


------
https://chatgpt.com/codex/tasks/task_e_687797c81858832c918a64dcf2c27c5d