### PR TITLE
Fix reward recording support for heuristic agent

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -297,6 +297,10 @@ class LongestChainAgent:
     def record_transition(self, s, a, r, s_next, done):
         """このエージェントでは未使用"""
         pass
+    def record_reward(self, r):
+        """このエージェントでは未使用"""
+        pass
+
 
     def finish_episode(self):
         """このエージェントでは未使用"""


### PR DESCRIPTION
## Summary
- add `record_reward` stub to `LongestChainAgent`

## Testing
- `python -m py_compile agents.py`
- *(failed: `pip install numpy torch tqdm pygame matplotlib` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687811029344832cbc9008e5d858c171