### PR TITLE
Enable parallel and GPU training

### DIFF
--- a/evaluate_models.py
+++ b/evaluate_models.py
@@ -23,10 +23,11 @@ def evaluate_model(
     policy_path=MODEL_DIR / "policy_agent_trained.pth",
     opponent_agent=None,
     num_episodes=1000,
-    board_size=9
+    board_size=9,
+    device=None,
 ):
     """
-    保存済みのモデル(PolicyAgent)を読み込み、opponent_agent と複数回対戦させて
+    保存済みのモデル(PolicyAgent)を読み込み、指定した相手と複数回対戦させて
     黒番(PolicyAgent)の勝率を返す。
 
     引数:
@@ -34,12 +35,13 @@ def evaluate_model(
       opponent_agent: 対戦相手(Agentのインスタンス)
       num_episodes: 対戦回数
       board_size: 盤面サイズ
+      device: 使用デバイス ("cuda" / "cpu" など)
 
     戻り値:
       win_rate: 黒番の勝率 (0.0 ~ 1.0)
     """
     # 1) 評価対象のPolicyAgentを読み込み
-    black_agent = PolicyAgent(board_size=board_size)
+    black_agent = PolicyAgent(board_size=board_size, device=device)
     black_agent.load_model(policy_path)  # 事前に学習済みモデルを読み込む
     black_agent.model.eval()  # 評価モード
 

--- a/parallel_train.py
+++ b/parallel_train.py
@@ -200,6 +200,7 @@ def update_with_trajectories(agent, all_episodes):
 
     all_episodes: [episode_log, episode_log, ...]
       ここで episode_log は [(state_tensor, action, reward), (state_tensor, action, reward), ...]
+    agent.device に従いテンソルを GPU / CPU へ転送する。
     """
     import torch
     import torch.nn.functional as F
@@ -225,11 +226,11 @@ def update_with_trajectories(agent, all_episodes):
     if len(all_states) == 0:
         return 0.0  # 何も学習することがなかった場合
 
-    # テンソル化
+    # --- 各エピソードから集めたデータをテンソルに変換しデバイスへ送る ---
     import torch
-    states_tensor = torch.cat(all_states, dim=0)       # shape: (N, board_size*board_size)
-    actions_tensor = torch.tensor(all_actions, dtype=torch.long)  # shape: (N,)
-    returns_tensor = torch.tensor(all_returns, dtype=torch.float32)  # shape: (N,)
+    states_tensor = torch.cat(all_states, dim=0).to(agent.device)
+    actions_tensor = torch.tensor(all_actions, dtype=torch.long).to(agent.device)
+    returns_tensor = torch.tensor(all_returns, dtype=torch.float32).to(agent.device)
 
     logits = agent.model(states_tensor)
     log_probs = F.log_softmax(logits, dim=1)

--- a/train_policy_vs_longest.py
+++ b/train_policy_vs_longest.py
@@ -1,56 +1,83 @@
 # -*- coding: utf-8 -*-
-"""PolicyAgentをLongestChainAgentに対して学習させるスクリプト
+"""PolicyAgent を LongestChainAgent に対して学習させるスクリプト
 
-学習過程の報酬や勝率を可視化する。学習終了後にはモデルを保存し、
-簡易的な評価も行う。
+必要に応じて複数プロセスを利用することで、学習を高速化できる。
+学習過程の報酬や勝率を可視化し、学習後はモデル保存と簡易評価を行う。
 """
 
 from pathlib import Path
+import argparse
+import torch
+
 from gomoku_env import GomokuEnv
 from agents import PolicyAgent, LongestChainAgent
 from learning_all_in_one import train_agents, plot_results
 from evaluate_models import evaluate_model
+from parallel_train import train_master
 
 # モデル保存用ディレクトリ
 MODEL_DIR = Path(__file__).resolve().parent / "models"
 
 
 def main():
-    """学習実行用メイン関数"""
-    # ----- ハイパーパラメータ設定 -----
-    board_size = 9
-    episodes = 1000  # 必要に応じて増減させる
+    """コマンドライン引数を受け取って学習を実行する"""
 
-    # 環境生成 (特に追加ルールは設けない)
-    env = GomokuEnv(board_size=board_size)
-
-    # 黒番に学習するPolicyAgent、白番にLongestChainAgentを配置
-    black_agent = PolicyAgent(board_size=board_size)
-    white_agent = LongestChainAgent()
-
-    # ----- 学習開始 -----
-    print("学習を開始します...")
-    rewards_b, rewards_w, winners, turns = train_agents(
-        env, black_agent, white_agent, episodes
+    parser = argparse.ArgumentParser(
+        description="PolicyAgent を LongestChainAgent と対戦させて学習する"
     )
+    parser.add_argument("--episodes", type=int, default=1000, help="学習エピソード数")
+    parser.add_argument("--board-size", type=int, default=9, help="盤面サイズ")
+    parser.add_argument("--num-workers", type=int, default=1, help="並列ワーカー数")
+    parser.add_argument("--device", default=None, help="使用デバイス(cuda/cpu)")
+    args = parser.parse_args()
+
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    board_size = args.board_size
+
+    if args.num_workers > 1:
+        # 並列学習モード
+        # train_master() は複数プロセスでエピソードを収集し
+        # まとめて方策勾配法で更新を行う
+        agent_params = {"device": device}
+        black_agent, rewards_b, winners, turns = train_master(
+            total_episodes=args.episodes,
+            board_size=board_size,
+            num_workers=args.num_workers,
+            agent_params=agent_params,
+            opponent_class=LongestChainAgent,
+        )
+        # 白番の報酬は黒番の報酬に符号を反転させて近似
+        rewards_w = [-r if r != 0 else 0 for r in rewards_b]
+    else:
+        # 単一プロセスでの学習
+        env = GomokuEnv(board_size=board_size)
+        black_agent = PolicyAgent(board_size=board_size, device=device)
+        white_agent = LongestChainAgent()
+
+        # 単純な1プロセス学習
+        print("学習を開始します...")
+        rewards_b, rewards_w, winners, turns = train_agents(
+            env, black_agent, white_agent, args.episodes
+        )
 
     # モデルを保存
     save_path = MODEL_DIR / "policy_vs_longest.pth"
     black_agent.save_model(save_path)
 
-    # ----- 学習過程の可視化 -----
-    plot_results(rewards_b, rewards_w, winners, turns,
-                 title="Policy vs LongestChain")
+    # 学習過程の可視化
+    plot_results(rewards_b, rewards_w, winners, turns, title="Policy vs LongestChain")
 
-    # ----- 簡易評価 -----
+    # 簡易評価
     win_rate = evaluate_model(
         policy_path=save_path,
         opponent_agent=LongestChainAgent(),
         num_episodes=200,
         board_size=board_size,
+        device=device,
     )
     print(f"学習後の勝率: {win_rate:.2f}")
 
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add device option to `PolicyAgent` to allow GPU usage
- update evaluation to accept device parameter
- ensure parallel training sends tensors to the chosen device
- extend `train_policy_vs_longest.py` with CLI, parallel execution, and device support

## Testing
- `python -m py_compile agents.py evaluate_models.py parallel_train.py train_policy_vs_longest.py`
- `python train_policy_vs_longest.py --episodes 1 --num-workers 1 --device cpu` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687813886c0c832cb884ce3fab0701d0