### PR TITLE
Fix reward handling for losing agent

### DIFF
--- a/learning_all_in_one.py
+++ b/learning_all_in_one.py
@@ -1042,7 +1042,20 @@ def train_agents(
 
             obs = next_obs
 
-        # エピソード終了
+        # ゲームが終了した時点で勝敗に応じて敗者側にも報酬を記録する
+        winner = info["winner"]
+        if winner == 1:
+            # 黒勝ちなら白に敗北報酬を与える
+            white_agent.record_reward(-1.0)
+        elif winner == 2:
+            # 白勝ちなら黒に敗北報酬を与える
+            black_agent.record_reward(-1.0)
+        elif winner == -1:
+            # 引き分けは双方に0報酬としておく
+            white_agent.record_reward(0.0)
+            black_agent.record_reward(0.0)
+
+        # エピソード終了後に方策の更新処理を呼び出す
         black_agent.finish_episode()
         white_agent.finish_episode()
 

--- a/parallel_train.py
+++ b/parallel_train.py
@@ -67,6 +67,14 @@ def play_one_episode(env, agent_black, agent_white, policy_color="black"):
     winner = info["winner"]
     turn_count = env.turn_count
 
+    # 勝敗が決したあと、学習対象が負けていたら最後の行動に敗北報酬を与える
+    if (policy_color == "black" and winner == 2) or (
+        policy_color == "white" and winner == 1
+    ):
+        policy_agent.record_reward(-1.0)
+    elif winner == -1:
+        policy_agent.record_reward(0.0)
+
     # 今エピソードで追加された分のログを抽出
     end_log_len = len(policy_agent.episode_log)
     episode_log = policy_agent.episode_log[start_log_len:end_log_len]


### PR DESCRIPTION
## Summary
- penalize losing agent at the end of each game
- apply the same logic to parallel training mode

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68781d942a3c832c86faab2d35d097b9