### PR TITLE
Refactor utils into smaller modules

### DIFF
--- a/gomoku/core/board_utils.py
+++ b/gomoku/core/board_utils.py
@@ -1,0 +1,136 @@
+"""盤面操作に関するユーティリティをまとめたモジュール"""
+
+from __future__ import annotations
+
+# 標準ライブラリ
+from typing import List
+import numpy as np
+
+# ------------------------------------------------------------
+# プレイヤーID関連のヘルパー
+# ------------------------------------------------------------
+
+def opponent_player(player: int) -> int:
+    """相手プレイヤーのIDを返す"""
+    # 1なら2、2なら1を返すだけ
+    return 2 if player == 1 else 1
+
+
+# ------------------------------------------------------------
+# 合法手の列挙および確率・Q値マスク関連
+# ------------------------------------------------------------
+
+def get_valid_actions(obs: np.ndarray, env) -> List[int]:
+    """盤面 ``obs`` と環境 ``env`` から着手可能な行動を列挙する"""
+    empty_positions = np.argwhere(obs == 0)
+
+    valid_actions: List[int] = []
+    for x, y in empty_positions:
+        ix = int(x)
+        iy = int(y)
+        if env.can_place_stone(ix, iy):
+            valid_actions.append(env.coord_to_action(ix, iy))
+    return valid_actions
+
+
+def mask_probabilities(probs: np.ndarray, valid_actions: List[int]) -> np.ndarray:
+    """無効手を除外して確率分布を再正規化する"""
+    masked_probs = np.zeros_like(probs)
+    for a in valid_actions:
+        masked_probs[a] = probs[a]
+
+    total = masked_probs.sum()
+    if total > 0.0:
+        masked_probs /= total
+    return masked_probs
+
+
+def mask_q_values(
+    q_values: np.ndarray,
+    valid_actions: List[int],
+    invalid_value: float = -1e9,
+) -> np.ndarray:
+    """無効手の Q 値を ``invalid_value`` で塗りつぶす"""
+    masked_q = q_values.copy()
+    invalid_mask = np.ones_like(masked_q, dtype=bool)
+    for a in valid_actions:
+        invalid_mask[a] = False
+    masked_q[invalid_mask] = invalid_value
+    return masked_q
+
+
+# ------------------------------------------------------------
+# 連の探索関連
+# ------------------------------------------------------------
+# 各方向を表す (dx, dy) ペア
+DIRECTIONS = [(1, 0), (0, 1), (1, 1), (1, -1)]
+
+
+def longest_chain_length(
+    obs: np.ndarray,
+    x: int,
+    y: int,
+    player: int,
+    directions: list[tuple[int, int]] = DIRECTIONS,
+) -> int:
+    """石を置いたと仮定したときの最長連結長を計算する"""
+
+    board_size = obs.shape[0]
+    max_len = 1
+
+    for dx, dy in directions:
+        count = 1
+
+        cx, cy = x + dx, y + dy
+        while 0 <= cx < board_size and 0 <= cy < board_size and obs[cx, cy] == player:
+            count += 1
+            cx += dx
+            cy += dy
+
+        cx, cy = x - dx, y - dy
+        while 0 <= cx < board_size and 0 <= cy < board_size and obs[cx, cy] == player:
+            count += 1
+            cx -= dx
+            cy -= dy
+
+        if count > max_len:
+            max_len = count
+
+    return max_len
+
+
+def has_n_in_a_row(
+    obs: np.ndarray,
+    x: int,
+    y: int,
+    player: int,
+    n: int,
+    directions: list[tuple[int, int]] = DIRECTIONS,
+) -> bool:
+    """``n`` 連以上が完成するかどうかを判定"""
+    return longest_chain_length(obs, x, y, player, directions) >= n
+
+
+def find_chain_move(
+    obs: np.ndarray,
+    valid_actions: List[int],
+    player: int,
+    n: int,
+    directions: list[tuple[int, int]] = DIRECTIONS,
+) -> int | None:
+    """``n`` 連を作れる着手があればその ``action`` を返す"""
+
+    board_size = obs.shape[0]
+
+    for a in valid_actions:
+        x = a // board_size
+        y = a % board_size
+
+        # 実際に置く前に仮置きしてチェック
+        obs[x, y] = player
+        if has_n_in_a_row(obs, x, y, player, n, directions):
+            obs[x, y] = 0
+            return a
+        obs[x, y] = 0
+
+    return None

--- a/gomoku/core/general_utils.py
+++ b/gomoku/core/general_utils.py
@@ -1,0 +1,54 @@
+"""一般的なユーティリティ関数をまとめたモジュール"""
+
+# 標準ライブラリ
+from typing import Sequence, List
+from pathlib import Path
+
+# サードパーティ
+import numpy as np
+
+# ------------------------------------------------------------
+# 図を保存するディレクトリ
+#   - GUI が使えない環境でも学習状況を確認できるよう、
+#     生成したグラフ画像をここへ集約する
+# ------------------------------------------------------------
+FIGURE_DIR = Path(__file__).resolve().parents[2] / "figures"
+FIGURE_DIR.mkdir(exist_ok=True)
+
+
+def moving_average(data: Sequence[float], window: int) -> List[float]:
+    """移動平均を計算して ``list`` で返す
+
+    Parameters
+    ----------
+    data : Sequence[float]
+        計算対象となる数値列
+    window : int
+        移動平均に用いる窓幅
+    """
+
+    if window <= 0:
+        raise ValueError("window must be positive")
+
+    # 元データを numpy 配列へ変換して計算を高速化
+    data_array = np.asarray(data, dtype=float)
+    n = data_array.size
+    if n == 0:
+        return []
+
+    # 累積和を利用すると O(n) で計算できる
+    cumsum = np.cumsum(data_array)
+    result = np.empty(n, dtype=float)
+
+    if n <= window:
+        # データ数が窓幅以下なら単純平均のみ
+        result[:] = cumsum / (np.arange(n) + 1)
+        return result.tolist()
+
+    # 先頭 ``window`` 要素分は部分平均
+    result[:window] = cumsum[:window] / (np.arange(window) + 1)
+
+    # 差分を取れば常に ``window`` 長の和が得られる
+    result[window:] = (cumsum[window:] - cumsum[:-window]) / window
+
+    return result.tolist()

--- a/gomoku/core/replay_buffer.py
+++ b/gomoku/core/replay_buffer.py
@@ -1,0 +1,36 @@
+"""経験再生用バッファ ``ReplayBuffer`` を提供するモジュール"""
+
+# 標準ライブラリ
+import random
+import collections
+from typing import Deque
+import numpy as np
+
+
+class ReplayBuffer:
+    """シンプルな経験再生バッファ"""
+
+    def __init__(self, capacity: int = 10000) -> None:
+        # 最大容量 ``capacity`` を超えると古いデータから自動的に削除される
+        self.buffer: Deque = collections.deque(maxlen=capacity)
+
+    def push(self, s: np.ndarray, a: int, r: float, s_next: np.ndarray, done: bool) -> None:
+        """1 ステップ分の遷移を追加する"""
+        # ``s`` と ``s_next`` は盤面を表す ``(board_size, board_size)`` 形状を想定
+        self.buffer.append((s, a, r, s_next, done))
+
+    def sample(
+        self, batch_size: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """蓄積したデータからランダムに ``batch_size`` 件取り出す"""
+        batch = random.sample(self.buffer, batch_size)
+        s, a, r, s_next, d = zip(*batch)
+        states = np.stack(s).astype(np.float32)
+        next_states = np.stack(s_next).astype(np.float32)
+        actions = np.array(a, dtype=np.int64)
+        rewards = np.array(r, dtype=np.float32)
+        dones = np.array(d, dtype=np.float32)
+        return states, actions, rewards, next_states, dones
+
+    def __len__(self) -> int:
+        return len(self.buffer)

--- a/gomoku/core/utils.py
+++ b/gomoku/core/utils.py
@@ -1,247 +1,38 @@
-# utils.py
-"""汎用的なユーティリティ関数をまとめたモジュール"""
+"""共通ユーティリティの公開窓口
 
-from typing import Sequence, List
-import random
-import collections
-from pathlib import Path
-import numpy as np
+各種サブモジュールへ分割した実装をまとめて再公開する。
+既存コードとの互換性を保つため、このモジュールから
+従来と同じ名前でインポートできるようにしている。
+"""
 
-# ------------------------------------------------------------
-# 描画結果を保存するフォルダ
-#   - GUI の無い環境でも学習過程を確認できるよう、
-#     グラフ画像をここへまとめて保存する
-# ------------------------------------------------------------
-# サブディレクトリに配置されたため二階層上を基準にする
-FIGURE_DIR = Path(__file__).resolve().parents[2] / "figures"
-FIGURE_DIR.mkdir(exist_ok=True)
+# 一般用途の関数・定数
+from .general_utils import FIGURE_DIR, moving_average
 
+# 盤面操作系の関数
+from .board_utils import (
+    opponent_player,
+    get_valid_actions,
+    mask_probabilities,
+    mask_q_values,
+    DIRECTIONS,
+    longest_chain_length,
+    has_n_in_a_row,
+    find_chain_move,
+)
 
-def moving_average(data: Sequence[float], window: int) -> List[float]:
-    """指定された窓幅で移動平均を計算する
+# 学習時に利用する経験再生バッファ
+from .replay_buffer import ReplayBuffer
 
-    Parameters
-    ----------
-    data : Sequence[float]
-        計算対象となる数値列。
-    window : int
-        移動平均の窓幅。正の整数でなければならない。
-
-    Returns
-    -------
-    List[float]
-        ``data`` と同じ長さの移動平均列を返す。
-    """
-
-    if window <= 0:
-        raise ValueError("window must be positive")
-
-    # Python のシーケンスを NumPy 配列へ変換
-    # "arr" だと意味が分かりにくいので data_array としている
-    data_array = np.asarray(data, dtype=float)
-    n = data_array.size
-    if n == 0:
-        return []
-
-    # 累積和(cumsum)を利用して計算量を削減
-    cumsum = np.cumsum(data_array)
-    # 結果格納用の配列を用意
-    result = np.empty(n, dtype=float)
-
-    if n <= window:
-        # シンプルに先頭からの平均のみ
-        result[:] = cumsum / (np.arange(n) + 1)
-        return result.tolist()
-
-    # まず先頭 window 要素分は部分平均
-    result[:window] = cumsum[:window] / (np.arange(window) + 1)
-
-    # 以降は前後差分で window 長の和を求めて平均
-    result[window:] = (cumsum[window:] - cumsum[:-window]) / window
-
-    return result.tolist()
-
-
-def opponent_player(player: int) -> int:
-    """与えられたプレイヤーID(1 or 2)の相手プレイヤーIDを返す"""
-    # 1なら2、2なら1を返すだけのシンプルな関数
-    return 2 if player == 1 else 1
-
-# ------------------------------------------------------------
-# 盤面関連のユーティリティ
-# ------------------------------------------------------------
-
-def get_valid_actions(obs: np.ndarray, env) -> list[int]:
-    """盤面と環境から合法手を列挙して返す"""
-    # 空きマスの座標をまとめて取得
-    empty_positions = np.argwhere(obs == 0)
-
-    valid_actions: list[int] = []
-    # それぞれのマスについて着手可能かを判定
-    for x, y in empty_positions:
-        ix = int(x)
-        iy = int(y)
-        if env.can_place_stone(ix, iy):
-            # 座標から action 番号へ変換して登録
-            valid_actions.append(env.coord_to_action(ix, iy))
-
-    return valid_actions
-
-
-def mask_probabilities(probs: np.ndarray, valid_actions: list[int]) -> np.ndarray:
-    """確率分布から無効手を除外して再正規化する"""
-    # 全て0で初期化した配列を用意
-    masked_probs = np.zeros_like(probs)
-
-    # 有効手に対応する要素だけをコピー
-    for a in valid_actions:
-        masked_probs[a] = probs[a]
-
-    # 合計が0でなければ正規化して確率分布を保つ
-    total = masked_probs.sum()
-    if total > 0.0:
-        masked_probs /= total
-
-    return masked_probs
-
-
-def mask_q_values(q_values: np.ndarray, valid_actions: list[int], invalid_value: float = -1e9) -> np.ndarray:
-    """無効手のQ値を ``invalid_value`` で置き換える"""
-    # 変更前の配列を残したいのでコピーを作成
-    masked_q = q_values.copy()
-
-    # True が無効手を示すブール配列を生成
-    invalid_mask = np.ones_like(masked_q, dtype=bool)
-    # 有効手の位置だけ False に切り替える
-
-    # 許可された手は False にしてマスクを外す
-    for a in valid_actions:
-        invalid_mask[a] = False
-
-    # マスクされた箇所は非常に小さい値で塗りつぶす
-    masked_q[invalid_mask] = invalid_value
-
-    return masked_q
-
-
-# ------------------------------------------------------------
-# 連を評価する際に利用する方向ベクトル
-# ------------------------------------------------------------
-# (dx, dy) = (1, 0)  : 縦方向
-#            (0, 1)  : 横方向
-#            (1, 1)  : 右下への斜め
-#            (1, -1) : 右上への斜め
-DIRECTIONS = [(1, 0), (0, 1), (1, 1), (1, -1)]
-
-
-def longest_chain_length(
-    obs: np.ndarray,
-    x: int,
-    y: int,
-    player: int,
-    directions: list[tuple[int, int]] = DIRECTIONS,
-) -> int:
-    """指定座標に石を置いたと仮定したときの最長連結長を返すヘルパー"""
-
-    board_size = obs.shape[0]
-    max_len = 1  # 置いた石自身を含むので初期値は1
-
-    # 4 方向それぞれについて連の長さを調べる
-    for dx, dy in directions:
-        count = 1  # 基点の石
-
-        # ---- 正方向への探索 ----
-        cx, cy = x + dx, y + dy
-        while 0 <= cx < board_size and 0 <= cy < board_size and obs[cx, cy] == player:
-            count += 1
-            cx += dx
-            cy += dy
-
-        # ---- 逆方向への探索 ----
-        cx, cy = x - dx, y - dy
-        while 0 <= cx < board_size and 0 <= cy < board_size and obs[cx, cy] == player:
-            count += 1
-            cx -= dx
-            cy -= dy
-
-        # 基点を中心とした1本の連が完成したので最大値を更新
-        if count > max_len:
-            max_len = count
-
-    return max_len
-
-
-def has_n_in_a_row(
-    obs: np.ndarray,
-    x: int,
-    y: int,
-    player: int,
-    n: int,
-    directions: list[tuple[int, int]] = DIRECTIONS,
-) -> bool:
-    """n 連以上が成立するかどうかを判定"""
-
-    return longest_chain_length(obs, x, y, player, directions) >= n
-
-
-def find_chain_move(
-    obs: np.ndarray,
-    valid_actions: list[int],
-    player: int,
-    n: int,
-    directions: list[tuple[int, int]] = DIRECTIONS,
-) -> int | None:
-    """n 連を作れる着手を探して返す。存在しなければ ``None``"""
-
-    board_size = obs.shape[0]
-
-    for a in valid_actions:
-        x = a // board_size
-        y = a % board_size
-
-        # --------------------------------------------
-        # 実際に打つ前に一時的に石を置いてみる
-        # 盤面を壊さず連ができるかどうかを調べるため
-        # --------------------------------------------
-        obs[x, y] = player
-        if has_n_in_a_row(obs, x, y, player, n, directions):
-            obs[x, y] = 0
-            return a
-        # 連ができなければ盤面を元に戻して次の候補へ
-        obs[x, y] = 0
-
-    return None
-
-
-class ReplayBuffer:
-    """経験再生用のシンプルなバッファ
-
-    ゲーム中に得られる状態 ``s``、行動 ``a``、報酬 ``r`` などの遷移を
-    一時的に蓄積し、学習時にランダムサンプリングしてミニバッチとして
-    取り出す用途を想定している。典型的な強化学習ループでは、各ステップ
-    ごとに :meth:`push` で追加し、学習関数内で :meth:`sample` を呼び出す。
-    """
-
-    def __init__(self, capacity: int = 10000) -> None:
-        self.buffer: collections.deque = collections.deque(maxlen=capacity)
-
-    def push(self, s: np.ndarray, a: int, r: float, s_next: np.ndarray, done: bool) -> None:
-        """1ステップ分の遷移を保存"""
-        # s, s_next は (board_size, board_size) の盤面配列を想定
-        # 例: board_size=9 の場合は (9, 9) の二次元配列
-        self.buffer.append((s, a, r, s_next, done))
-
-    def sample(self, batch_size: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """ランダムに ``batch_size`` 件取り出し NumPy 配列として返す"""
-        batch = random.sample(self.buffer, batch_size)
-        s, a, r, s_next, d = zip(*batch)
-        # states, next_states: (batch_size, board_size, board_size)
-        states = np.stack(s).astype(np.float32)
-        next_states = np.stack(s_next).astype(np.float32)
-        actions = np.array(a, dtype=np.int64)
-        rewards = np.array(r, dtype=np.float32)
-        dones = np.array(d, dtype=np.float32)
-        return states, actions, rewards, next_states, dones
-
-    def __len__(self) -> int:
-        return len(self.buffer)
+__all__ = [
+    "FIGURE_DIR",
+    "moving_average",
+    "opponent_player",
+    "get_valid_actions",
+    "mask_probabilities",
+    "mask_q_values",
+    "DIRECTIONS",
+    "longest_chain_length",
+    "has_n_in_a_row",
+    "find_chain_move",
+    "ReplayBuffer",
+]


### PR DESCRIPTION
## Summary
- break up `gomoku/core/utils.py` into smaller modules
- add `board_utils.py`, `general_utils.py`, and `replay_buffer.py`
- keep old interface by re-exporting symbols from `utils.py`

## Testing
- `python -m compileall -q gomoku`

------
https://chatgpt.com/codex/tasks/task_e_6878dd22549c832cb9c7f47fdb68e15e