### PR TITLE
Refactor learning utilities

### DIFF
--- a/gomoku/scripts/config_defaults.py
+++ b/gomoku/scripts/config_defaults.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""学習用スクリプトで使うデフォルト設定をまとめたモジュール"""
+
+# ``learning_all_in_one.py`` などで共通利用する設定を一箇所に集約する。
+# 実験用に値を調整したい場合はこのファイルを編集するだけで済む。
+
+DEFAULT_CONFIG = {
+    "board_size": 9,
+    "episodes": 2000,
+    "env_params": {
+        "force_center_first_move": False,
+        "adjacency_range": None,  # None で制限なし
+        "invalid_move_penalty": -1.0,
+        "reward_chain_2_open2": 0.01,
+        "reward_chain_3_open2": 0.5,
+        "reward_chain_4_open2": 0.8,
+        "reward_chain_2_open1": 0.0,
+        "reward_chain_3_open1": 0.05,
+        "reward_chain_4_open1": 0.4,
+        "reward_block_2_open2": 0.05,
+        "reward_block_3_open2": 0.6,
+        "reward_block_4_open2": 0.0,
+        "reward_block_2_open1": 0.0,
+        "reward_block_3_open1": 0.05,
+        "reward_block_4_open1": 0.9,
+    },
+    "policy_params": {
+        "board_size": 9,
+        "hidden_size": 128,
+        "lr": 1e-3,
+        "gamma": 0.95,
+        "temp": 2.0,
+        "min_temp": 0.5,
+        "temp_decay": 0.999,
+        "entropy_coef": 0.01,
+    },
+    "q_params": {
+        "board_size": 9,
+        "hidden_size": 256,
+        "lr": 1e-3,
+        "gamma": 0.90,
+        "epsilon_start": 1.0,
+        "epsilon_end": 0.1,
+        "epsilon_decay": 20000,
+        "replay_capacity": 100000,
+        "batch_size": 64,
+        "update_frequency": 10,
+        "target_update_frequency": 200,
+    }
+}
+
+__all__ = ["DEFAULT_CONFIG"]

--- a/gomoku/scripts/learning_all_in_one.py
+++ b/gomoku/scripts/learning_all_in_one.py
@@ -6,16 +6,9 @@
 
 from pathlib import Path
 
-from ..core.gomoku_env import GomokuEnv
-from ..ai.agents import (
-    RandomAgent,
-    ImmediateWinBlockAgent,
-    FourThreePriorityAgent,
-    LongestChainAgent,
-    PolicyAgent,
-    QAgent,
-)
-from .learning_utils import train_agents, plot_results, run_match_pygame
+# 可能な限りシンプルな構成とするため、詳細な処理は別モジュールに分割した
+from .config_defaults import DEFAULT_CONFIG
+from .learning_runner import train_q_vs_q, play_trained_match
 
 # 学習済みモデルを保存するディレクトリ
 MODEL_DIR = Path(__file__).resolve().parents[2] / "models"
@@ -27,130 +20,19 @@ MODEL_DIR = Path(__file__).resolve().parents[2] / "models"
 # ------------------------------------------------------------
 
 def main():
-    # ------------------------------
-    # 例: ハイパーパラメータ設定
-    # ------------------------------
-    config = {
-        "board_size": 9,
-        "episodes": 2000,
-        "env_params": {
-            "force_center_first_move": False,
-            "adjacency_range": None,  # None で制限なし
-            "invalid_move_penalty": -1.0,
-            "reward_chain_2_open2": 0.01,
-            "reward_chain_3_open2": 0.5,
-            "reward_chain_4_open2": 0.8,
-            "reward_chain_2_open1": 0.0,
-            "reward_chain_3_open1": 0.05,
-            "reward_chain_4_open1": 0.4,
-            "reward_block_2_open2": 0.05,
-            "reward_block_3_open2": 0.6,
-            "reward_block_4_open2": 0.0,
-            "reward_block_2_open1": 0.0,
-            "reward_block_3_open1": 0.05,
-            "reward_block_4_open1": 0.9,
-        },
-        "policy_params": {
-            "board_size": 9,
-            "hidden_size": 128,
-            "lr": 1e-3,
-            "gamma": 0.95,
-            "temp": 2.0,
-            "min_temp": 0.5,
-            "temp_decay": 0.999,
-            "entropy_coef": 0.01,
-        },
-        "q_params": {
-            "board_size": 9,
-            "hidden_size": 256,
-            "lr": 1e-3,
-            "gamma": 0.90,
-            "epsilon_start": 1.0,
-            "epsilon_end": 0.1,
-            "epsilon_decay": 20000,
-            "replay_capacity": 100000,
-            "batch_size": 64,
-            "update_frequency": 10,
-            "target_update_frequency": 200,
-        }
-    }
+    """デフォルト設定で QAgent 同士を学習させる"""
 
-    # 環境作成
-    env = GomokuEnv(board_size=config["board_size"], **config["env_params"])
+    # 設定は ``config_defaults`` にまとめてあるものをそのまま使用
+    config = DEFAULT_CONFIG
 
-    # ------------------------------
-    # 例1: Policy vs Policy (自己対戦)
-    # ------------------------------
-    # black_agent = PolicyAgent(**config["policy_params"])
-    # white_agent = PolicyAgent(**config["policy_params"])
-
-    # rew_b, rew_w, winners, turns = train_agents(env, black_agent, white_agent, config["episodes"])
-    # plot_results(rew_b, rew_w, winners, turns, title="Policy vs Policy")
-
-    # black_agent.save_model(MODEL_DIR / "policy_black.pth")
-    # white_agent.save_model(MODEL_DIR / "policy_white.pth")
-
-    # ------------------------------
-    # 例2: QAgent vs QAgent (自己対戦)
-    # ------------------------------
-    black_q = QAgent(**config["q_params"])
-    white_q = QAgent(**config["q_params"])
-
-    rew_b, rew_w, winners, turns = train_agents(env, black_q, white_q, config["episodes"])
-    # GUI が無い場合を考慮して show=False
-    plot_results(
-        rew_b,
-        rew_w,
-        winners,
-        turns,
-        title="Q vs Q",
-        show=False,
-    )
-
-    black_q.save_model(MODEL_DIR / "q_black.pth")
-    white_q.save_model(MODEL_DIR / "q_white.pth")
-
-    # ------------------------------
-    # 例3: ヒューリスティックAgent vs 学習Agent
-    #     (黒番: Policy, 白番: ImmediateWinBlock)
-    # ------------------------------
-    # env = GomokuEnv(board_size=config["board_size"], **config["env_params"])
-    # black_policy = PolicyAgent(**config["policy_params"])
-    # white_heuristic = LongestChainAgent()
-
-    # rew_b, rew_w, winners, turns = train_agents(env, black_policy, white_heuristic, config["episodes"])
-    # plot_results(rew_b, rew_w, winners, turns, title="Policy(Black) vs ImmediateWinBlock(White)")
-
-    # ------------------------------
-    # 例4: ヒューリスティックAgent vs 学習Agent
-    #     (黒番: QAgent, 白番: FourThreePriority)
-    # ------------------------------
-    # env = GomokuEnv(board_size=config["board_size"], **config["env_params"])
-    # black_q = QAgent(**config["q_params"])
-    # white_heuristic = LongestChainAgent()
-
-    # rew_b, rew_w, winners, turns = train_agents(env, black_q, white_heuristic, config["episodes"])
-    # plot_results(rew_b, rew_w, winners, turns, title="Q(Black) vs FourThreePriority(White)")
-
-
-    # 好みに合わせて学習させたい組み合わせを試してみてください。
+    # サンプルとして QAgent の自己対戦学習を実行
+    train_q_vs_q(config, show_plot=False)
 
     return config
 
 
 if __name__ == "__main__":
     config = main()
-    black_q = QAgent(**config["q_params"])
-    black_q.load_model(MODEL_DIR / "q_black.pth")
-
-    white_q = QAgent(**config["q_params"])
-    white_q.load_model(MODEL_DIR / "q_white.pth")
-
-    run_match_pygame(
-        black_q,
-        white_q,
-        board_size=config["board_size"],
-        pause_time=0.5,
-        env_params=config["env_params"],
-    )
+    # 学習済みモデルを読み込み 1 ゲームだけ対戦を可視化
+    play_trained_match(config, pause_time=0.5)
 

--- a/gomoku/scripts/learning_runner.py
+++ b/gomoku/scripts/learning_runner.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""学習実行の汎用処理をまとめたモジュール"""
+
+# 各スクリプトで重複していた処理を関数化し、再利用しやすくするための
+# ラッパー関数群。ここでは ``QAgent`` 同士の学習例と、
+# 学習済みモデルを用いた対戦実行を提供する。
+
+from pathlib import Path
+
+from ..core.gomoku_env import GomokuEnv
+from ..ai.agents import QAgent
+from .learning_utils import train_agents, plot_results, run_match_pygame
+
+# モデル保存先ディレクトリ
+MODEL_DIR = Path(__file__).resolve().parents[2] / "models"
+MODEL_DIR.mkdir(exist_ok=True)
+
+
+def train_q_vs_q(config: dict, show_plot: bool = False) -> tuple[QAgent, QAgent]:
+    """QAgent 同士を自己対戦させて学習させる簡易関数"""
+
+    # 環境を作成
+    env = GomokuEnv(board_size=config["board_size"], **config["env_params"])
+
+    # 黒番・白番とも同じハイパーパラメータで初期化
+    black_q = QAgent(**config["q_params"])
+    white_q = QAgent(**config["q_params"])
+
+    # 実際の学習ループは ``train_agents`` に任せる
+    rew_b, rew_w, winners, turns = train_agents(
+        env, black_q, white_q, config["episodes"]
+    )
+
+    # 成果をグラフ化し必要なら表示
+    plot_results(
+        rew_b,
+        rew_w,
+        winners,
+        turns,
+        title="Q vs Q",
+        show=show_plot,
+    )
+
+    # 学習済みモデルを保存
+    black_q.save_model(MODEL_DIR / "q_black.pth")
+    white_q.save_model(MODEL_DIR / "q_white.pth")
+
+    return black_q, white_q
+
+
+def load_trained_q_agents(config: dict) -> tuple[QAgent, QAgent]:
+    """保存済みの QAgent モデルを読み込んで返す"""
+
+    black_q = QAgent(**config["q_params"])
+    black_q.load_model(MODEL_DIR / "q_black.pth")
+
+    white_q = QAgent(**config["q_params"])
+    white_q.load_model(MODEL_DIR / "q_white.pth")
+
+    return black_q, white_q
+
+
+def play_trained_match(config: dict, pause_time: float = 0.5) -> None:
+    """保存済みモデル同士を PyGame で 1 試合だけ対戦させる"""
+
+    black_q, white_q = load_trained_q_agents(config)
+    run_match_pygame(
+        black_q,
+        white_q,
+        board_size=config["board_size"],
+        pause_time=pause_time,
+        env_params=config["env_params"],
+    )
+
+
+__all__ = ["train_q_vs_q", "load_trained_q_agents", "play_trained_match"]


### PR DESCRIPTION
## Summary
- centralize configuration defaults for experiments
- add `learning_runner` module with utility functions
- simplify `learning_all_in_one` to use the new helpers

## Testing
- `python -m compileall -q gomoku/scripts/config_defaults.py gomoku/scripts/learning_runner.py gomoku/scripts/learning_all_in_one.py`

------
https://chatgpt.com/codex/tasks/task_e_68795f6fadfc832c82538cfd74c9ac81