### PR TITLE
Add convolutional PolicyNet and update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - ランダムエージェント
   - 即勝ち・ブロック優先などのヒューリスティックエージェント
   - 方策勾配を用いた `PolicyAgent`
+    - 畳み込み型の `ConvPolicyNet` と全結合型の `PolicyNet` を選択可能
   - DQN を用いた `QAgent`
 - `gomoku/scripts` には GUI 対戦やモデル学習、評価、並列学習などのスクリプトを用意
 - 学習済みモデルは `models/` フォルダに保存
@@ -57,6 +58,8 @@ python -m gomoku.scripts.play_vs_model
 
 黒番として学習済み `PolicyAgent` をロードし、白番のランダムエージェントと対戦します。
 盤面はテキストで表示されます。
+既存のモデルが全結合ネットワークで学習されている場合は
+`network_type="dense"` を指定してください。
 
 ### 3. モデルを学習する
 
@@ -82,6 +85,8 @@ python -m gomoku.scripts.evaluate_models
 ```
 
 必要に応じて `policy_path` や `opponent_agent` を変更してください。
+全結合ネットワークで学習したモデルを評価する場合は
+`network_type="dense"` を引数に指定します。
 
 ### 5. 並列学習や総当たり戦
 

--- a/gomoku/ai/agents.py
+++ b/gomoku/ai/agents.py
@@ -14,6 +14,7 @@ from .heuristic import (
 from .policy_agent import (
     EpisodeStep,
     PolicyNet,
+    ConvPolicyNet,
     PolicyAgent,
 )
 
@@ -30,6 +31,7 @@ __all__ = [
     "LongestChainAgent",
     "EpisodeStep",
     "PolicyNet",
+    "ConvPolicyNet",
     "PolicyAgent",
     "QNet",
     "QAgent",

--- a/gomoku/scripts/evaluate_models.py
+++ b/gomoku/scripts/evaluate_models.py
@@ -26,6 +26,7 @@ def evaluate_model(
     board_size=9,
     device=None,
     policy_color="black",
+    network_type="dense",
 ):
     """
     保存済みモデル(PolicyAgent)を読み込み、指定した相手と複数回対戦させて
@@ -43,7 +44,9 @@ def evaluate_model(
       win_rate: PolicyAgent の勝率 (0.0 ~ 1.0)
     """
     # 1) 評価対象のPolicyAgentを読み込み
-    policy_agent = PolicyAgent(board_size=board_size, device=device)
+    policy_agent = PolicyAgent(
+        board_size=board_size, device=device, network_type=network_type
+    )
     policy_agent.load_model(policy_path)  # 事前に学習済みモデルを読み込む
     policy_agent.model.eval()  # 評価モード
 
@@ -109,5 +112,6 @@ if __name__ == "__main__":
         policy_path=MODEL_DIR / "policy_agent_trained.pth",
         opponent_agent=FourThreePriorityAgent(),
         num_episodes=100,
-        board_size=9
+        board_size=9,
+        network_type="dense",
     )

--- a/gomoku/scripts/play_vs_model.py
+++ b/gomoku/scripts/play_vs_model.py
@@ -16,7 +16,9 @@ from ..ai.agents import PolicyAgent, RandomAgent
 # スクリプトディレクトリから二階層上の ``models`` フォルダを参照
 MODEL_DIR = Path(__file__).resolve().parents[2] / "models"
 
-def play_game_with_trained_model(policy_path=MODEL_DIR / "policy_agent_trained.pth"):
+def play_game_with_trained_model(
+    policy_path=MODEL_DIR / "policy_agent_trained.pth", network_type="dense"
+):
     """
     学習済みモデルを用いて1ゲームだけ対戦を行う関数。
 
@@ -37,7 +39,7 @@ def play_game_with_trained_model(policy_path=MODEL_DIR / "policy_agent_trained.p
     # 学習済みモデルを読み込んだPolicyAgent(黒番)とRandomAgent(白番)で対戦
     env = GomokuEnv(board_size=9)
     # 黒番となる学習済みエージェントを初期化
-    black_agent = PolicyAgent(board_size=9)
+    black_agent = PolicyAgent(board_size=9, network_type=network_type)
     black_agent.load_model(policy_path)
 
     # 白番は単純なランダムエージェント
@@ -68,4 +70,6 @@ def play_game_with_trained_model(policy_path=MODEL_DIR / "policy_agent_trained.p
         print("引き分け")
 
 if __name__ == "__main__":
-    play_game_with_trained_model(MODEL_DIR / "policy_agent_trained.pth")
+    play_game_with_trained_model(
+        MODEL_DIR / "policy_agent_trained.pth", network_type="dense"
+    )

--- a/gomoku/scripts/play_with_pygame.py
+++ b/gomoku/scripts/play_with_pygame.py
@@ -16,10 +16,15 @@ if __name__ == "__main__":
         env_params={"force_center_first_move": False, "adjacency_range": 1},
         black_agent_type="policy",
         black_agent_path=MODEL_DIR / "policy_agent_black.pth",
-        black_agent_params={"hidden_size": 128, "lr": 1e-3, "gamma": 0.95},
+        black_agent_params={
+            "hidden_size": 128,
+            "lr": 1e-3,
+            "gamma": 0.95,
+            "network_type": "dense",
+        },
         white_agent_type="policy",
         white_agent_path=MODEL_DIR / "policy_agent_white.pth",
-        white_agent_params={},
+        white_agent_params={"network_type": "dense"},
         visualize=True,
         fps=2,
     )

--- a/gomoku/scripts/round_robin.py
+++ b/gomoku/scripts/round_robin.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     agentC = FourThreePriorityAgent()
     agentD = LongestChainAgent()
 
-    agentP = PolicyAgent(board_size=9)
+    agentP = PolicyAgent(board_size=9, network_type="dense")
     agentP.load_model(MODEL_DIR / "policy_agent_black.pth")
 
     agentQ = QAgent(board_size=9)

--- a/gomoku/scripts/train_policy_mixed.py
+++ b/gomoku/scripts/train_policy_mixed.py
@@ -76,7 +76,9 @@ def train_policy_mixed(
 
     # 相手エージェントを用意
     heuristic_agent = LongestChainAgent()
-    opponent_policy = PolicyAgent(board_size=board_size, device=device)
+    opponent_policy = PolicyAgent(
+        board_size=board_size, device=device, network_type="dense"
+    )
     opponent_policy.load_model(opponent_policy_path)
 
     wins = []
@@ -108,6 +110,7 @@ def train_policy_mixed(
         board_size=board_size,
         device=device,
         policy_color=policy_color,
+        network_type="conv",
     )
     wr_p = evaluate_model(
         policy_path=save_path,
@@ -116,6 +119,7 @@ def train_policy_mixed(
         board_size=board_size,
         device=device,
         policy_color=policy_color,
+        network_type="conv",
     )
     print(f"LongestChainAgent への勝率: {wr_h:.2f}")
     print(f"既存 PolicyAgent への勝率: {wr_p:.2f}")


### PR DESCRIPTION
## Summary
- implement `ConvPolicyNet` and add network type selection in `PolicyAgent`
- expose `ConvPolicyNet` from `ai.agents`
- adapt evaluation and play scripts to specify `network_type` when using old models
- document the new network option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879697355f8832c8e097e21f6e8bf5f