### PR TITLE
Fix network type mismatch in policy training evaluation

### DIFF
--- a/gomoku/scripts/train_policy_vs_longest.py
+++ b/gomoku/scripts/train_policy_vs_longest.py
@@ -149,7 +149,11 @@ def main():
         show=False,
     )
 
-    # 簡易評価
+    # ------------------------------------------------------------
+    # 学習したモデルの簡易評価
+    #   ConvPolicyNet で学習しているため
+    #   評価時にも同じネットワーク設定を渡す
+    # ------------------------------------------------------------
     win_rate = evaluate_model(
         policy_path=save_path,
         opponent_agent=LongestChainAgent(),
@@ -157,6 +161,7 @@ def main():
         board_size=board_size,
         device=device,
         policy_color=policy_color,
+        network_type="conv",
     )
     print(f"学習後の勝率: {win_rate:.2f}")
 


### PR DESCRIPTION
## Summary
- ensure `train_policy_vs_longest.py` evaluates the trained convolutional model correctly by passing `network_type="conv"` to `evaluate_model`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796d35420c832cadf941cbc007f9d5