### PR TITLE
Add text-based eval during training

### DIFF
--- a/gomoku/scripts/learning_runner.py
+++ b/gomoku/scripts/learning_runner.py
@@ -28,7 +28,10 @@ def train_q_vs_q(config: dict, show_plot: bool = False) -> tuple[QAgent, QAgent]
 
     # 実際の学習ループは ``train_agents`` に任せる
     rew_b, rew_w, winners, turns = train_agents(
-        env, black_q, white_q, config["episodes"]
+        env,
+        black_q,
+        white_q,
+        episodes=config["episodes"],
     )
 
     # 成果をグラフ化し必要なら表示

--- a/gomoku/scripts/learning_utils.py
+++ b/gomoku/scripts/learning_utils.py
@@ -10,17 +10,40 @@ from ..core.gomoku_env import GomokuEnv
 from ..core.utils import moving_average, FIGURE_DIR
 # play_with_pygame.py にはサンプル用の実行コードのみ存在するため
 # 実際のゲームロジックを提供する play_utils.py から ``play_game`` を読み込む
-from .play_utils import play_game
+from .play_utils import play_game, play_game_text
 
 
-def train_agents(env, black_agent, white_agent, episodes=1000):
-    """自己対戦によりエージェントを学習させる汎用ループ"""
+def train_agents(
+    env,
+    black_agent,
+    white_agent,
+    episodes: int = 1000,
+    eval_interval: int = 0,
+    eval_pause: float = 0.0,
+):
+    """自己対戦によりエージェントを学習させる汎用ループ
+
+    Parameters
+    ----------
+    env : GomokuEnv
+        学習に使用する環境インスタンス
+    black_agent : Any
+        黒番のエージェント
+    white_agent : Any
+        白番のエージェント
+    episodes : int, optional
+        学習エピソード数
+    eval_interval : int, optional
+        ``eval_interval`` > 0 のとき、この間隔でテキスト対戦を表示する
+    eval_pause : float, optional
+        テキスト対戦表示時の待ち時間 (秒)
+    """
     all_rewards_black = []
     all_rewards_white = []
     winners = []
     turns_list = []
 
-    for _ in tqdm(range(episodes), desc="train_agents"):
+    for ep in tqdm(range(episodes), desc="train_agents"):
         obs = env.reset()
         done = False
         black_episode_reward = 0.0
@@ -64,6 +87,11 @@ def train_agents(env, black_agent, white_agent, episodes=1000):
         turns_list.append(env.turn_count)
         all_rewards_black.append(black_episode_reward)
         all_rewards_white.append(white_episode_reward)
+
+        # --- 指定エピソード毎にテキスト対戦を実行 ------------------
+        if eval_interval > 0 and (ep + 1) % eval_interval == 0:
+            print(f"\n[評価] エピソード {ep + 1} 時点での対戦例")
+            play_game_text(env, black_agent, white_agent, pause=eval_pause)
 
     return all_rewards_black, all_rewards_white, winners, turns_list
 

--- a/gomoku/scripts/play_utils.py
+++ b/gomoku/scripts/play_utils.py
@@ -61,6 +61,43 @@ def play_game(env: GomokuEnv, black_agent, white_agent, visualize: bool = True, 
     return winner, black_reward, turn_count
 
 
+def play_game_text(env: GomokuEnv, black_agent, white_agent, pause: float = 0.0):
+    """テキストのみで 1 ゲームを実行し盤面を逐次表示する"""
+
+    # --- 環境を初期化し最初の盤面を表示 -----------------------------
+    obs = env.reset()
+    done = False
+    env.render()
+
+    # --- ゲームが終わるまで行動と描画を繰り返す ---------------------
+    while not done:
+        # 手番に応じてエージェントを切り替える
+        if env.current_player == 1:
+            action = black_agent.get_action(obs, env)
+        else:
+            action = white_agent.get_action(obs, env)
+
+        # 行動を適用し盤面を更新
+        obs, reward, done, info = env.step(action)
+
+        # 現在の盤面を表示
+        env.render()
+        if pause > 0:
+            time.sleep(pause)
+
+    # --- 勝者を判定し情報を返す -----------------------------------
+    winner = info["winner"]
+    if winner == 1:
+        black_reward = 1.0
+    elif winner == 2:
+        black_reward = -1.0
+    else:
+        black_reward = 0.0
+    turn_count = env.turn_count
+
+    return winner, black_reward, turn_count
+
+
 def play_agents_vs_agents(
     board_size: int = 9,
     num_games: int = 1,
@@ -126,5 +163,5 @@ def play_agents_vs_agents(
     )
 
 
-__all__ = ["play_game", "play_agents_vs_agents"]
+__all__ = ["play_game", "play_game_text", "play_agents_vs_agents"]
 

--- a/gomoku/scripts/train_policy_vs_longest.py
+++ b/gomoku/scripts/train_policy_vs_longest.py
@@ -128,7 +128,10 @@ def main():
         # 単純な1プロセス学習
         print("学習を開始します...")
         rewards_b, rewards_w, winners, turns = train_agents(
-            env, black_agent, white_agent, args.episodes
+            env,
+            black_agent,
+            white_agent,
+            episodes=args.episodes,
         )
 
     # モデルを保存 (学習対象エージェント)


### PR DESCRIPTION
## Summary
- display text-based matches with `play_game_text`
- allow `train_agents` to trigger ASCII evaluations
- expose new helper via `__all__`
- adjust scripts to new helper signature

## Testing
- `python - <<'EOF'
from gomoku.core.gomoku_env import GomokuEnv
from gomoku.ai.agents import PolicyAgent
from gomoku.scripts.learning_utils import train_agents

env = GomokuEnv(board_size=5)
black = PolicyAgent(board_size=5)
white = PolicyAgent(board_size=5)
train_agents(env, black, white, episodes=2, eval_interval=1, eval_pause=0)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68797fdf94cc832c8da0261c66f301ce