### PR TITLE
Add QAgent evaluation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ python -m gomoku.scripts.evaluate_models
 必要に応じて `policy_path` や `opponent_agent` を変更してください。
 全結合ネットワークで学習したモデルを評価する場合は
 `network_type="dense"` を引数に指定します。
+`QAgent` を評価したい場合は `--agent_type q --q_path <モデルファイル>` を
+付与してください。
 
 ### 5. 並列学習や総当たり戦
 


### PR DESCRIPTION
## Summary
- allow `evaluate_models.py` to load `QAgent` models via new argument
- refactor evaluation logic for unified handling of opponents
- update README with instructions on evaluating `QAgent`

## Testing
- `python -m py_compile gomoku/scripts/evaluate_models.py`
- `python -m compileall -q gomoku`

------
https://chatgpt.com/codex/tasks/task_e_687985fa5750832ca4fa9c83f5345d1d