### PR TITLE
Improve parallel QAgent training

### DIFF
--- a/gomoku/scripts/parallel_q_train.py
+++ b/gomoku/scripts/parallel_q_train.py
@@ -12,10 +12,22 @@ from ..core.gomoku_env import GomokuEnv
 from ..ai.agents import QAgent, RandomAgent
 
 
-def play_one_episode_q(env, q_agent, opponent_agent):
-    """QAgent(黒)と opponent_agent(白) の1ゲームを実行する。"""
+def _update_epsilon(agent: QAgent, steps: int) -> None:
+    """epsilon を自前で更新する補助関数"""
+    for _ in range(steps):
+        agent.epsilon_step += 1
+        ratio = min(1.0, agent.epsilon_step / agent.epsilon_decay)
+        agent.epsilon = (1.0 - ratio) * agent.epsilon + ratio * agent.epsilon_end
+
+
+def play_one_episode_q(env, q_agent, opponent_agent, collect_transitions=False):
+    """QAgent(黒)と opponent_agent(白) の1ゲームを実行する。
+
+    ``collect_transitions`` が True のときは学習を行わず、遷移情報を
+    返すだけの動作になる。"""
     obs = env.reset()
     done = False
+    transitions = []
 
     while not done:
         current_player = env.current_player
@@ -30,9 +42,12 @@ def play_one_episode_q(env, q_agent, opponent_agent):
         # 1手進める
         next_obs, reward, done, info = env.step(action)
 
-        # 黒(QAgent)が打った場合のみ学習データとして保存
+        # 黒(QAgent)が打った場合の処理
         if current_player == 1:
-            q_agent.record_transition(state, action, reward, next_obs, done)
+            if collect_transitions:
+                transitions.append((state, action, reward, next_obs, done))
+            else:
+                q_agent.record_transition(state, action, reward, next_obs, done)
 
         obs = next_obs
 
@@ -47,6 +62,8 @@ def play_one_episode_q(env, q_agent, opponent_agent):
     else:
         r_for_black = 0.0
 
+    if collect_transitions:
+        return r_for_black, winner, turn_count, transitions
     return r_for_black, winner, turn_count
 
 
@@ -55,23 +72,35 @@ def train_worker_q(
     num_episodes,
     board_size,
     agent_params,
+    model_state,
     opponent_class,
     env_params=None,
 ):
-    """ワーカー側で QAgent を生成し複数エピソードを実行する。"""
+    """ワーカー側で QAgent を生成し複数エピソードを実行する。
+
+    ``model_state`` で渡された重みをロードし、学習は行わずに遷移
+    情報のみを収集する。"""
     if env_params is None:
         env_params = {}
 
     q_agent = QAgent(board_size=board_size, **agent_params)
+    q_agent.qnet.load_state_dict(model_state)
     white_agent = opponent_class()
 
     env = GomokuEnv(board_size=board_size, **env_params)
 
     local_data = []
+    transitions = []
     for _ in range(num_episodes):
-        r_for_black, winner, turn_count = play_one_episode_q(env, q_agent, white_agent)
+        r_for_black, winner, turn_count, trans = play_one_episode_q(
+            env,
+            q_agent,
+            white_agent,
+            collect_transitions=True,
+        )
         local_data.append((r_for_black, winner, turn_count))
-    return local_data, q_agent
+        transitions.extend(trans)
+    return local_data, transitions
 
 
 def train_master_q(
@@ -83,7 +112,11 @@ def train_master_q(
     env_params=None,
     opponent_class=None,
 ):
-    """QAgent を並列で学習する簡易例。"""
+    """QAgent を並列で学習する簡易例。
+
+    1 つの QAgent をマスター側で保持し、各ワーカーはモデルの重みを
+    受け取って遷移のみを収集する。集めた遷移はマスターでまとめて
+    ``train_on_batch`` を呼び出しながら学習を進める。"""
     if agent_params is None:
         agent_params = {}
     if env_params is None:
@@ -93,6 +126,9 @@ def train_master_q(
 
     episodes_per_worker = total_episodes // num_workers
 
+    # マスターで共有する QAgent を生成
+    q_agent = QAgent(board_size=board_size, **agent_params)
+
     all_rewards = []
     all_winners = []
     all_turn_counts = []
@@ -100,6 +136,8 @@ def train_master_q(
     # 並列実行。CUDA 利用時もエラーにならないよう spawn 方式を選ぶ
     with multiprocessing.get_context("spawn").Pool(num_workers) as pool:
         worker_args = []
+        # モデルの重みは CPU テンソルへ変換して渡す
+        model_state = {k: v.detach().cpu() for k, v in q_agent.qnet.state_dict().items()}
         for wid in range(num_workers):
             worker_args.append(
                 (
@@ -107,20 +145,23 @@ def train_master_q(
                     episodes_per_worker,
                     board_size,
                     agent_params,
+                    model_state,
                     opponent_class,
                     env_params,
                 )
             )
         results = pool.starmap(train_worker_q, worker_args)
 
-    # 各ワーカーの結果をまとめる
-    for (local_data, worker_q_agent) in results:
+    # 取得した遷移をマスターのエージェントへ集約
+    for (local_data, transitions) in results:
         for (r, w, t) in local_data:
             all_rewards.append(r)
             all_winners.append(w)
             all_turn_counts.append(t)
+        for trans in transitions:
+            q_agent.buffer.push(*trans)
+            _update_epsilon(q_agent, 1)
+            if len(q_agent.buffer) >= batch_size:
+                q_agent.train_on_batch()
 
-    # とりあえず先頭のワーカーで学習したエージェントを返す
-    final_agent = results[0][1]
-
-    return final_agent, all_rewards, all_winners, all_turn_counts
+    return q_agent, all_rewards, all_winners, all_turn_counts

--- a/gomoku/scripts/train_q_vs_heuristics.py
+++ b/gomoku/scripts/train_q_vs_heuristics.py
@@ -75,6 +75,8 @@ def train_q_vs_heuristics(
 
     for phase, opp in enumerate(opponent_classes, start=1):
         print(f"\n==== フェーズ {phase}: 対戦相手 = {opp.__name__} ====")
+        # `train_master_q` はワーカーから得た遷移をマスター側で学習する
+        # 方式に変更されたため、返り値のエージェントが常に最新のものとなる
         q_agent, rewards, winners, _ = train_master_q(
             total_episodes=episodes_per_phase,
             batch_size=max(1, episodes_per_phase // num_workers),


### PR DESCRIPTION
## Summary
- refactor `parallel_q_train` to use a single QAgent in the master process
- collect transitions in workers and train in the master
- add helper for epsilon update and explanatory comments
- note new data flow in `train_q_vs_heuristics`

## Testing
- `python -m py_compile gomoku/scripts/parallel_q_train.py`
- `python -m py_compile gomoku/scripts/train_q_vs_heuristics.py`
- *(failed to run training scripts due to spawn issues in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_687996798884832ca5e1972f330b1ae1