### PR TITLE
Fix unbound variable bug in parallel_q_train

### DIFF
--- a/gomoku/scripts/parallel_q_train.py
+++ b/gomoku/scripts/parallel_q_train.py
@@ -162,6 +162,9 @@ def train_master_q(
 
     def _run(active_pool):
         """与えられたプールで実際の並列処理を行う内部関数"""
+        # 外側の remaining を更新する必要があるため nonlocal 宣言する
+        nonlocal remaining
+
         pbar = tqdm(total=total_episodes, desc="Training", disable=(not show_progress))
         for _ in range(n_batches):
             batch_eps = min(batch_size, remaining)


### PR DESCRIPTION
## Summary
- handle `remaining` in inner `_run` function using `nonlocal`
- add explanatory Japanese comment

## Testing
- `python -m gomoku.scripts.train_q_vs_heuristics --device cpu --episodes 3 --num-workers 1 --check-interval 1 --no-progress | grep -n "勝率" | head`


------
https://chatgpt.com/codex/tasks/task_e_6879beb971b4832c828b3c4dc27271f0