### PR TITLE
Synchronize check-interval defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ python -m gomoku.scripts.train_q_vs_heuristics --episodes 500 --device cuda
 早期終了時に次のフェーズへ進むかを確認してくれます。最後に 1 戦だけテキス
 ト表示で対局結果を確認できます。GPU を利用する場合は ``--device cuda`` を
 指定します。
+なお評価間隔は ``--check-interval`` オプションで変更可能で、
+デフォルトは 100 エピソードごととなっています。
 
 ## 注意点
 

--- a/gomoku/scripts/train_q_vs_heuristics.py
+++ b/gomoku/scripts/train_q_vs_heuristics.py
@@ -31,6 +31,10 @@ from ..ai.agents import (
 MODEL_DIR = Path(__file__).resolve().parents[2] / "models"
 MODEL_DIR.mkdir(exist_ok=True)
 
+# check_interval のデフォルト値を定数として定義
+# CLI と関数の両方で同じ値を使うことで設定ミスを防ぐ
+DEFAULT_CHECK_INTERVAL = 100
+
 
 def train_q_vs_heuristics(
     episodes_per_phase: int = 500,
@@ -44,7 +48,7 @@ def train_q_vs_heuristics(
     stop_win_rate: float = 0.9,
     interactive: bool = False,
     show_progress: bool = True,
-    check_interval: int = 100,
+    check_interval: int = DEFAULT_CHECK_INTERVAL,
 ):
     """複数のヒューリスティック相手に QAgent を順番に学習させる
 
@@ -180,7 +184,7 @@ def main() -> None:
     parser.add_argument(
         "--check-interval",
         type=int,
-        default=100,
+        default=DEFAULT_CHECK_INTERVAL,
         help="勝率確認を行うエピソード間隔",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- centralize default check interval in `train_q_vs_heuristics.py`
- document `--check-interval` option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879e6699a70832ca0675a944dfb671b