### PR TITLE
Update training docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ python -m gomoku.scripts.train_policy_mixed --episodes 2000
 python -m gomoku.scripts.train_q_vs_heuristics --episodes 500 --device cuda
 ```
 
+盤面サイズを小さくして手早く試す場合は次のように指定します。
+
+```bash
+python -m gomoku.scripts.train_q_vs_heuristics --board-size 5 --episodes 100
+```
+
+より安定した結果を得るためにエピソード数を増やしたいときは以下のように実行します。
+
+```bash
+python -m gomoku.scripts.train_q_vs_heuristics --episodes 2000 --device cuda
+```
+
 学習は ``check_interval`` ごとに勝率を確認し、伸びがほぼ無くなった段階で
 フェーズを途中終了します。 ``--interactive`` オプションを付けると、この
 早期終了時に次のフェーズへ進むかを確認してくれます。最後に 1 戦だけテキス

--- a/gomoku/scripts/train_q_vs_heuristics.py
+++ b/gomoku/scripts/train_q_vs_heuristics.py
@@ -6,6 +6,11 @@ parallel_q_train.train_master_q() を呼び出し、相手クラスを変えな�
 簡易的なプラトー判定により学習を早期終了することもある。
 最終的に play_utils.play_game_text() を用いて 1 戦だけ対局を再現し、
 盤面を ASCII 表示する。
+
+盤面サイズは ``--board-size`` オプションで変更できる。5×5 など小さめにすると
+学習時間を短縮でき、15×15 のように大きめにするとより実戦的な検証が可能。
+各フェーズのエピソード数も ``--episodes`` で調整でき、少ない値で素早く動作確認を、
+大きい値では安定した学習を期待できる。
 """
 
 from __future__ import annotations
@@ -183,7 +188,9 @@ def demo_play(q_agent, opponent_agent, board_size: int = 9) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="QAgent 段階学習デモ")
     parser.add_argument("--episodes", type=int, default=500, help="各フェーズのエピソード数")
+    # 例: 100 なら素早く動作確認、2000 以上ならじっくり学習
     parser.add_argument("--board-size", type=int, default=9, help="盤面サイズ")
+    # 例: 5 を指定すると 5x5 の小盤面で高速に検証できる
     parser.add_argument("--num-workers", type=int, default=4, help="並列ワーカー数")
     parser.add_argument("--device", default=None, help="使用デバイス(cuda/cpu)")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- expand docstring in `train_q_vs_heuristics.py` with tips on adjusting board size and episode count
- add inline comments on how to try different values
- extend README with concrete command examples for small boards and longer training

## Testing
- `python -m py_compile gomoku/scripts/train_q_vs_heuristics.py`

------
https://chatgpt.com/codex/tasks/task_e_6879eed917ec832c9b473518a6dcc7a7