### PR TITLE
Support convolutional QAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   - 即勝ち・ブロック優先などのヒューリスティックエージェント
   - 方策勾配を用いた `PolicyAgent`
     - 畳み込み型の `ConvPolicyNet` と全結合型の `PolicyNet` を選択可能
-  - DQN を用いた `QAgent`
+  - DQN を用いた `QAgent` (全結合版と畳み込み版を選択可能)
 - `gomoku/scripts` には GUI 対戦やモデル学習、評価、並列学習などのスクリプトを用意
 - 学習曲線などの画像は `figures/` フォルダに出力
 - 学習済みモデルは容量削減のためリポジトリに含まれていません。必要に応じて個別にダウンロードしてください。
@@ -88,7 +88,8 @@ python -m gomoku.scripts.evaluate_models
 全結合ネットワークで学習したモデルを評価する場合は
 `network_type="dense"` を引数に指定します。
 `QAgent` を評価したい場合は `--agent_type q --q_path <モデルファイル>` を
-付与してください。
+付与してください。QAgent も `--q_network_type conv` を指定することで
+畳み込み版のモデルを読み込めます。
 
 ### 5. 並列学習や総当たり戦
 
@@ -131,6 +132,8 @@ python -m gomoku.scripts.train_q_vs_heuristics --episodes 500 --device cuda
 指定します。
 なお評価間隔は ``--check-interval`` オプションで変更可能で、
 デフォルトは 100 エピソードごととなっています。
+畳み込み型のネットワークで学習したい場合は `--network-type conv` を
+指定してください。
 
 ## 注意点
 

--- a/gomoku/ai/agents.py
+++ b/gomoku/ai/agents.py
@@ -20,6 +20,8 @@ from .policy_agent import (
 
 # DQN エージェント関連
 from .q_agent import (
+    FCQNet,
+    ConvQNet,
     QNet,
     QAgent,
 )
@@ -33,6 +35,8 @@ __all__ = [
     "PolicyNet",
     "ConvPolicyNet",
     "PolicyAgent",
+    "FCQNet",
+    "ConvQNet",
     "QNet",
     "QAgent",
 ]

--- a/gomoku/scripts/agent_factory.py
+++ b/gomoku/scripts/agent_factory.py
@@ -17,6 +17,7 @@ def create_agent(agent_type: str, board_size: int, agent_path: Path | None = Non
     agent_type の文字列から適切なエージェントインスタンスを生成する。
 
     - ``policy`` / ``q`` などモデル読み込みを伴うタイプは ``agent_path`` を用いる。
+    - ``agent_params`` に ``network_type`` を与えるとネットワーク形式を切り替えられる。
     - 指定が不明な場合は ``RandomAgent`` を返す。
     """
     if agent_params is None:

--- a/gomoku/scripts/evaluate_models.py
+++ b/gomoku/scripts/evaluate_models.py
@@ -30,6 +30,7 @@ def evaluate_model(
     device=None,
     policy_color="black",
     network_type="dense",
+    q_network_type="fc",
     eval_temp=0.5,
     agent_type="policy",
 ):
@@ -60,7 +61,9 @@ def evaluate_model(
         eval_agent.model.eval()
         eval_agent.temp = eval_temp
     else:
-        eval_agent = QAgent(board_size=board_size)
+        eval_agent = QAgent(
+            board_size=board_size, device=device, network_type=q_network_type
+        )
         eval_agent.load_model(q_path)
 
     def play_single_game(black, white) -> int:
@@ -172,6 +175,12 @@ if __name__ == "__main__":
         default="dense",
         help="PolicyAgent のネットワーク形式",
     )
+    parser.add_argument(
+        "--q_network_type",
+        choices=["fc", "conv"],
+        default="fc",
+        help="QAgent のネットワーク形式",
+    )
 
     args = parser.parse_args()
 
@@ -194,6 +203,7 @@ if __name__ == "__main__":
         device=args.device,
         policy_color=args.policy_color,
         network_type=args.network_type,
+        q_network_type=args.q_network_type,
         eval_temp=args.eval_temp,
         agent_type=args.agent_type,
     )

--- a/gomoku/scripts/train_q_vs_heuristics.py
+++ b/gomoku/scripts/train_q_vs_heuristics.py
@@ -202,11 +202,17 @@ def main() -> None:
         default=DEFAULT_CHECK_INTERVAL,
         help="勝率確認を行うエピソード間隔",
     )
+    parser.add_argument(
+        "--network-type",
+        choices=["fc", "conv"],
+        default="fc",
+        help="QAgent のネットワーク形式",
+    )
     args = parser.parse_args()
 
     device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
 
-    agent_params = {"device": device}
+    agent_params = {"device": device, "network_type": args.network_type}
 
     q_agent, last_opponent = train_q_vs_heuristics(
         episodes_per_phase=args.episodes,


### PR DESCRIPTION
## Summary
- implement ConvQNet and rename existing QNet to FCQNet
- allow QAgent to switch network type via `network_type` argument
- update agent exports
- add `--network-type` and `--q_network_type` options to relevant scripts
- document usage of convolutional QAgent in README

## Testing
- `python -m py_compile gomoku/ai/q_agent.py gomoku/ai/agents.py gomoku/scripts/train_q_vs_heuristics.py gomoku/scripts/evaluate_models.py gomoku/scripts/agent_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_6879eed741a0832ca826a78ea14827a3